### PR TITLE
✨ Feat: Swagger 문서화 및 API 응답 통일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,14 +37,14 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+ .idea/artifacts
+ .idea/compiler.xml
+ .idea/jarRepositories.xml
+ .idea/modules.xml
+ .idea/*.iml
+ .idea/modules
+ *.iml
+ *.ipr
 
 # CMake
 cmake-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@
  .idea/jarRepositories.xml
  .idea/modules.xml
  .idea/*.iml
- .idea/modules
+ .idea/modules/**
  *.iml
  *.ipr
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/site/moamoa/backend/api_payload/ApiResponseDTO.java
+++ b/src/main/java/site/moamoa/backend/api_payload/ApiResponseDTO.java
@@ -1,0 +1,47 @@
+package site.moamoa.backend.api_payload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import site.moamoa.backend.api_payload.code.BaseCode;
+import site.moamoa.backend.api_payload.code.status.SuccessStatus;
+
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public record ApiResponseDTO<T>(
+        @JsonProperty("isSuccess")
+        Boolean isSuccess,
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        T result
+) {
+
+    //Success
+    public static <T> ApiResponseDTO<T> onSuccess(T result) {
+        return new ApiResponseDTO<>(
+                true,
+                SuccessStatus._OK.getCode(),
+                SuccessStatus._OK.getMessage(),
+                result
+        );
+    }
+
+    public static <T> ApiResponseDTO<T> of(BaseCode code, T result) {
+        return new ApiResponseDTO<>(
+                true,
+                code.getReasonHttpStatus().code(),
+                code.getReasonHttpStatus().message(),
+                result
+        );
+    }
+
+    //Fail
+    public static <T> ApiResponseDTO<T> onFailure(String code, String message, T data) {
+        return new ApiResponseDTO<>(
+                true,
+                code,
+                message,
+                data
+        );
+    }
+}

--- a/src/main/java/site/moamoa/backend/api_payload/code/BaseCode.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/BaseCode.java
@@ -1,0 +1,9 @@
+package site.moamoa.backend.api_payload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+
+}

--- a/src/main/java/site/moamoa/backend/api_payload/code/BaseErrorCode.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package site.moamoa.backend.api_payload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+
+}

--- a/src/main/java/site/moamoa/backend/api_payload/code/ErrorReasonDTO.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/ErrorReasonDTO.java
@@ -1,0 +1,13 @@
+package site.moamoa.backend.api_payload.code;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ErrorReasonDTO(
+        HttpStatus httpStatus,
+        boolean isSuccess,
+        String code,
+        String message
+) {
+}

--- a/src/main/java/site/moamoa/backend/api_payload/code/ReasonDTO.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/ReasonDTO.java
@@ -1,0 +1,13 @@
+package site.moamoa.backend.api_payload.code;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ReasonDTO(
+        HttpStatus httpStatus,
+        boolean isSuccess,
+        String code,
+        String message
+) {
+}

--- a/src/main/java/site/moamoa/backend/api_payload/code/status/ErrorStatus.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/status/ErrorStatus.java
@@ -1,0 +1,43 @@
+package site.moamoa.backend.api_payload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import site.moamoa.backend.api_payload.code.BaseErrorCode;
+import site.moamoa.backend.api_payload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .isSuccess(false)
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return  ErrorReasonDTO.builder()
+                .isSuccess(false)
+                .message(message)
+                .code(code)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/site/moamoa/backend/api_payload/code/status/SuccessStatus.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/status/SuccessStatus.java
@@ -1,0 +1,39 @@
+package site.moamoa.backend.api_payload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import site.moamoa.backend.api_payload.code.BaseCode;
+import site.moamoa.backend.api_payload.code.ReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/site/moamoa/backend/api_payload/exception/ExceptionAdvice.java
+++ b/src/main/java/site/moamoa/backend/api_payload/exception/ExceptionAdvice.java
@@ -1,0 +1,117 @@
+package site.moamoa.backend.api_payload.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import site.moamoa.backend.api_payload.ApiResponseDTO;
+import site.moamoa.backend.api_payload.code.ErrorReasonDTO;
+import site.moamoa.backend.api_payload.code.status.ErrorStatus;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity<Object> onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponseDTO<Object> body = ApiResponseDTO.onFailure(reason.code(),reason.message(),null);
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.httpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e,
+                                                                HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponseDTO<Object> body = ApiResponseDTO.onFailure(ErrorStatus._INTERNAL_SERVER_ERROR.getCode(), ErrorStatus._INTERNAL_SERVER_ERROR.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                HttpHeaders.EMPTY,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponseDTO<Object> body = ApiResponseDTO.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                HttpHeaders.EMPTY,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     WebRequest request) {
+        ApiResponseDTO<Object> body = ApiResponseDTO.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                HttpHeaders.EMPTY,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/site/moamoa/backend/api_payload/exception/GeneralException.java
+++ b/src/main/java/site/moamoa/backend/api_payload/exception/GeneralException.java
@@ -1,0 +1,22 @@
+package site.moamoa.backend.api_payload.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import site.moamoa.backend.api_payload.code.BaseErrorCode;
+import site.moamoa.backend.api_payload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+
+    private final BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+
+}

--- a/src/main/java/site/moamoa/backend/config/SwaggerConfig.java
+++ b/src/main/java/site/moamoa/backend/config/SwaggerConfig.java
@@ -1,0 +1,21 @@
+package site.moamoa.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("모아모아 서비스 API 명세서")
+                .version("0.1")
+                .description("모아모아 서비스의 API Docs 입니다.");
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/src/main/java/site/moamoa/backend/config/SwaggerConfig.java
+++ b/src/main/java/site/moamoa/backend/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
@@ -18,4 +19,5 @@ public class SwaggerConfig {
                 .components(new Components())
                 .info(info);
     }
+
 }

--- a/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
@@ -1,0 +1,47 @@
+package site.moamoa.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.moamoa.backend.api_payload.ApiResponseDTO;
+
+@Tag(name = "Keyword API", description = "검색어 관련 API")
+@RequiredArgsConstructor
+@RestController
+public class KeywordController {
+
+    @GetMapping("/api/keyword/ranking")
+    @Operation(
+            summary = "우리 동네 인기 검색어 조회 (개발중)",
+            description = "조회된 검색량을 기반으로 우리 동네 인기 검색어 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getKeywordsByRanking(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/keyword/recent")
+    @Operation(
+            summary = "사용자의 최근 검색어 조회 (개발중)",
+            description = "사용자가 최근에 검색한 검색어 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getKeywordsByRecent(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+}

--- a/src/main/java/site/moamoa/backend/web/controller/MemberController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/MemberController.java
@@ -1,0 +1,84 @@
+package site.moamoa.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.moamoa.backend.api_payload.ApiResponseDTO;
+
+@Tag(name = "Member API", description = "사용자 정보 관련 API")
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    @GetMapping("/api/member")
+    @Operation(
+            summary = "사용자 정보 조회 (개발중)",
+            description = "사용자의 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getMemberByNickname(
+            //TODO: Security 추가시 인증부 구현 필요
+            @Parameter(description = "사용자 이름", example = "Luke")
+            @RequestParam String nickname
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @PatchMapping("/api/member/image")
+    @Operation(
+            summary = "사용자 프로필 사진 수정 (개발중)",
+            description = "사용자의 프로필 사진 정보를 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> updateMyImage(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @PatchMapping("/api/member/location")
+    @Operation(
+            summary = "사용자 동네 수정 (개발중)",
+            description = "사용자의 동네 정보를 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> updateMyLocation(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/member/post")
+    @Operation(
+            summary = "사용자의 공동구매 참여 목록 조회 (개발중)",
+            description = "사용자의 공동구매 참여 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getPostsByParticipating(
+            //TODO: Security 추가시 인증부 구현 필요
+            @Parameter(description = "모집 마감 여부(ONGOING, END)", example = "END")
+            @RequestParam String status
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+}

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -1,0 +1,198 @@
+package site.moamoa.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import site.moamoa.backend.api_payload.ApiResponseDTO;
+
+@Tag(name = "Post API", description = "공동구매 페이지 관련 API")
+@RequiredArgsConstructor
+@RestController
+public class PostController {
+
+    @GetMapping("/api/post/ranking")
+    @Operation(
+            summary = "우리 동네 인기 공동구매 조회 (개발중)",
+            description = "조회수를 기반으로 우리 동네 인기 공동구매 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getPostsByRanking(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/post/latest")
+    @Operation(
+            summary = "최근 모집 시작한 공동구매 조회 (개발중)",
+            description = "최근 모집을 시작한 공동구매 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getPostsByLatest(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/post/near")
+    @Operation(
+            summary = "우리 동네 공동구매 조회 (개발중)",
+            description = "우리 동네 공동구매 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getPostsByNear(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/post/recent-keyword")
+    @Operation(
+            summary = "최근 검색한 키워드로 공동구매 조회 (개발중)",
+            description = "최근 검색한 공동구매 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getPostsByRecentKeyword(
+            //TODO: Security 추가시 인증부 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @PostMapping("/api/post")
+    @Operation(
+            summary = "공동구매 등록 (개발중)",
+            description = "공동구매 정보를 받아 새로운 공동구매 게시글을 등록합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> registerPost(
+            //TODO: Security 추가시 인증부 구현 필요
+            //TODO: @RequestBody 구현 필요
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @PatchMapping("/api/post/{postId}")
+    @Operation(
+            summary = "공동구매 상세정보 수정 (개발중)",
+            description = "공동구매 정보를 받아 기존의 공동구매 게시글을 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> updatePost(
+            //TODO: Security 추가시 인증부 구현 필요
+            //TODO: @RequestBody 구현 필요
+            @PathVariable
+            @Positive(message = "게시글 ID는 양수입니다.")
+            @Schema(description = "게시글 ID", example = "1")
+            Long postId
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @PatchMapping("/api/post/{postId}/status")
+    @Operation(
+            summary = "공동구매 상태 변경 (개발중)",
+            description = "기존의 공동구매 상태를 변경합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> updatePostStatus(
+            //TODO: Security 추가시 인증부 구현 필요
+            @PathVariable
+            @Positive(message = "게시글 ID는 양수입니다.")
+            @Schema(description = "게시글 ID", example = "1")
+            Long postId
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/post/{postId}")
+    @Operation(
+            summary = "공동구매 상태 변경 (개발중)",
+            description = "기존의 공동구매 상태를 변경합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> getPost(
+            //TODO: Security 추가시 인증부 구현 필요
+            @PathVariable
+            @Positive(message = "게시글 ID는 양수입니다.")
+            @Schema(description = "게시글 ID", example = "1")
+            Long postId
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @PostMapping("/api/post/{postId}/join")
+    @Operation(
+            summary = "공동구매 참여 (개발중)",
+            description = "기존의 공동구매에 참여합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> joinPost(
+            //TODO: Security 추가시 인증부 구현 필요
+            @PathVariable
+            @Positive(message = "게시글 ID는 양수입니다.")
+            @Schema(description = "게시글 ID", example = "1")
+            Long postId
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+
+    @GetMapping("/api/post")
+    @Operation(
+            summary = "특정 키워드를 포함하는 공동구매 조회 (개발중)",
+            description = "특정 키워드가 포함된 공동구매 게시글 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    public ApiResponseDTO<?> searchKeywordPost(
+            //TODO: Security 추가시 인증부 구현 필요
+            @Parameter(description = "검색어", example = "사과")
+            @RequestParam final String keyword,
+            @Parameter(description = "카테고리", example = "식품")
+            @RequestParam final String category,
+            @Parameter(description = "모집까지 남은 일수", example = "4")
+            @RequestParam final Integer dDay,
+            @Parameter(description = "전체 모집 인원", example = "5")
+            @RequestParam final Integer total,
+            @Parameter(description = "최소 금액", example = "3000")
+            @RequestParam final Integer minPrice,
+            @Parameter(description = "최대 금액", example = "5000")
+            @RequestParam final Integer maxPrice
+    ) {
+        //TODO: 서비스 로직 추가 필요
+        return null;    //TODO: Result DTO 반환 필요
+    }
+}

--- a/src/main/java/site/moamoa/backend/web/controller/RootController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/RootController.java
@@ -1,12 +1,16 @@
 package site.moamoa.backend.web.controller;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 public class RootController {
+
     @GetMapping("/health")
     public String healthCheck() {
         return "Good!";
     }
+
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- swagger/8

### 💡 작업동기
- 글로 명세한 API를 Swagger를 통해 문서화합니다.
- API 구현을 위한 Response를 통일합니다.
- 응답에 사용될 Exception을 통일합니다. 

### 🔑 주요 변경사항
- Swagger 관련 의존성 추가
- SwaggerConfig 추가
- HealthCheck API의 명세를 Swagger 문서상에서 숨김
- API Payload 구현
- Base Exception 구현
- Swagger를 통한 API 문서화

### 🏞 스크린샷
![image](https://github.com/moa-moa-service/moamoa-backend/assets/52543606/5c103394-80a2-4b54-bbdf-f0ba42d01741)


### 관련 이슈
- #8 