### PR TITLE
♻️ [REFACTOR]: 검색 키워드 등록 및 조회 API 및 코드 개선

### DIFF
--- a/.idea/modules/backend.main.iml
+++ b/.idea/modules/backend.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-}
+//tasks.named('test') {
+//    useJUnitPlatform()
+//}
 
 jar {
     enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'site.moa-moa'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '17'
+    sourceCompatibility = '21'
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'site.moa-moa'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+    sourceCompatibility = '17'
 }
 
 configurations {
@@ -54,9 +54,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
-//tasks.named('test') {
-//    useJUnitPlatform()
-//}
+tasks.named('test') {
+    useJUnitPlatform()
+}
 
 jar {
     enabled = false

--- a/src/main/java/site/moamoa/backend/BackendApplication.java
+++ b/src/main/java/site/moamoa/backend/BackendApplication.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@OpenAPIDefinition(servers = {
-		@Server(url = "/", description = "Default Server URL")
-})
+
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/moamoa/backend/BackendApplication.java
+++ b/src/main/java/site/moamoa/backend/BackendApplication.java
@@ -1,11 +1,16 @@
 package site.moamoa.backend;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@OpenAPIDefinition(servers = {
+		@Server(url = "/", description = "Default Server URL")
+})
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandService.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandService.java
@@ -5,4 +5,6 @@ import site.moamoa.backend.web.dto.response.KeywordResponseDTO;
 public interface KeywordCommandService {
     //개인 최근 검색어 중 삭제
     KeywordResponseDTO.DeleteKeywordResult deleteRecentKeyword(Long memberId, String keyword);
+
+    void updateKeywordCount(Long memberId, String keyword);
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandService.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandService.java
@@ -4,7 +4,7 @@ import site.moamoa.backend.web.dto.response.KeywordResponseDTO;
 
 public interface KeywordCommandService {
     //개인 최근 검색어 중 삭제
-    KeywordResponseDTO.DeleteKeywordResult deleteRecentKeyword(Long memberId, String keyword);
-
-    void updateKeywordCount(Long memberId, String keyword);
+    KeywordResponseDTO.DeleteKeywordResult deleteMemberKeyword(Long memberId, String keyword);
+    void addMemberKeyword(Long memberId, String keyword);
+    void updateTownKeywordCount(Long memberId, String keyword);
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandServiceImpl.java
@@ -20,16 +20,19 @@ public class KeywordCommandServiceImpl implements KeywordCommandService{
 
     //개인 최근 검색어 중 삭제
     @Override
-    public KeywordResponseDTO.DeleteKeywordResult deleteRecentKeyword(Long memberId, String keyword) {
+    public KeywordResponseDTO.DeleteKeywordResult deleteMemberKeyword(Long memberId, String keyword) {
         redisModuleService.deleteKeywordByMemberRecent(memberId, keyword);
 
         return KeywordConverter.toDeleteKeywordResult(memberId, LocalDateTime.now());
     }
 
     @Override
-    public void updateKeywordCount(Long memberId, String keyword) {
+    public void addMemberKeyword(Long memberId, String keyword) {
         redisModuleService.addKeywordToMemberRecent(memberId, keyword);
+    }
 
+    @Override
+    public void updateTownKeywordCount(Long memberId, String keyword) {
         String town = memberModuleService.findMemberById(memberId).getTown();
         redisModuleService.increaseTownKeywordCount(town, keyword);
     }

--- a/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/keyword/KeywordCommandServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.moamoa.backend.converter.KeywordConverter;
+import site.moamoa.backend.service.module.member.MemberModuleService;
 import site.moamoa.backend.service.module.redis.RedisModuleService;
 import site.moamoa.backend.web.dto.response.KeywordResponseDTO;
 
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 public class KeywordCommandServiceImpl implements KeywordCommandService{
 
     private RedisModuleService redisModuleService;
+    private final MemberModuleService memberModuleService;
 
     //개인 최근 검색어 중 삭제
     @Override
@@ -22,5 +24,13 @@ public class KeywordCommandServiceImpl implements KeywordCommandService{
         redisModuleService.deleteKeywordByMemberRecent(memberId, keyword);
 
         return KeywordConverter.toDeleteKeywordResult(memberId, LocalDateTime.now());
+    }
+
+    @Override
+    public void updateKeywordCount(Long memberId, String keyword) {
+        redisModuleService.addKeywordToMemberRecent(memberId, keyword);
+
+        String town = memberModuleService.findMemberById(memberId).getTown();
+        redisModuleService.increaseTownKeywordCount(town, keyword);
     }
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandService.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandService.java
@@ -19,7 +19,5 @@ public interface PostCommandService {
 
     AddMemberPostResult joinPost(Long memberId, Long postId);
 
-    void updateKeywordCount(Long memberId, String keyword);
-
     void updatePostViewCount(Long memberId, Long postId);
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -92,14 +92,6 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public void updateKeywordCount(Long memberId, String keyword) {
-        redisModuleService.addKeywordToMemberRecent(memberId, keyword);
-
-        String town = memberModuleService.findMemberById(memberId).getTown();
-        redisModuleService.increaseTownKeywordCount(town, keyword);
-    }
-
-    @Override
     public void updatePostViewCount(Long memberId, Long postId) {
         if (redisModuleService.isNewPostViewRecord(memberId, postId)) {
             Post post = postModuleService.findPostById(postId);

--- a/src/main/java/site/moamoa/backend/service/component/query/keyword/KeywordQueryService.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/keyword/KeywordQueryService.java
@@ -4,7 +4,7 @@ import site.moamoa.backend.web.dto.response.KeywordResponseDTO;
 
 public interface KeywordQueryService {
     //동네 인기 검색어 리스트 1위~10위까지 (조회수 기준)
-    KeywordResponseDTO.GetKeywords popularSearchRankList(String townName);
+    KeywordResponseDTO.GetKeywords popularSearchRankList(Long memberId);
 
     //개인 최근 검색어 리스트 1위~10위까지
     KeywordResponseDTO.GetKeywords recentSearchRankList(Long memberId);

--- a/src/main/java/site/moamoa/backend/service/component/query/keyword/KeywordQueryServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/keyword/KeywordQueryServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.moamoa.backend.converter.KeywordConverter;
+import site.moamoa.backend.service.module.member.MemberModuleServiceImpl;
 import site.moamoa.backend.service.module.redis.RedisModuleService;
 import site.moamoa.backend.web.dto.response.KeywordResponseDTO;
 
@@ -17,11 +18,12 @@ import java.util.Set;
 public class KeywordQueryServiceImpl implements KeywordQueryService {
 
     private final RedisModuleService redisModuleService;
+    private final MemberModuleServiceImpl memberQueryService;
 
     //동네 인기 검색어 리스트 1위~10위까지 (조회수 기준)
     @Override
-    public KeywordResponseDTO.GetKeywords popularSearchRankList(String townName) {
-        Set<ZSetOperations.TypedTuple<String>> typedTuples = redisModuleService.getKeywordByTownRanking(townName);
+    public KeywordResponseDTO.GetKeywords popularSearchRankList(Long memberId) {
+        Set<ZSetOperations.TypedTuple<String>> typedTuples = redisModuleService.getKeywordByTownRanking(memberQueryService.findMemberById(memberId).getTown());
 
         return KeywordConverter.toGetKeywords(
                 Objects.requireNonNull(typedTuples).stream().map(typedTuple -> KeywordConverter.toKeywordDTO(typedTuple.getValue())).toList());

--- a/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 import site.moamoa.backend.api_payload.ApiResponseDTO;
 import site.moamoa.backend.service.component.command.keyword.KeywordCommandService;
 import site.moamoa.backend.service.component.query.keyword.KeywordQueryService;
-import site.moamoa.backend.service.module.member.MemberModuleServiceImpl;
 import site.moamoa.backend.web.dto.base.AuthInfoDTO;
 
 import static site.moamoa.backend.web.dto.response.KeywordResponseDTO.DeleteKeywordResult;
@@ -26,7 +25,6 @@ public class KeywordController {
 
     private final KeywordCommandService keywordCommandService;
     private final KeywordQueryService keywordQueryService;
-    private final MemberModuleServiceImpl memberQueryService;
 
     @GetMapping("/api/keywords/ranking")
     @Operation(
@@ -39,8 +37,9 @@ public class KeywordController {
     public ApiResponseDTO<GetKeywords> getKeywordsByRanking(
             @AuthenticationPrincipal AuthInfoDTO auth
     ) {
-        GetKeywords resultDTO = keywordQueryService.popularSearchRankList(memberQueryService.findMemberById(auth.id()).getTown());
+        GetKeywords resultDTO = keywordQueryService.popularSearchRankList(auth.id());
         return ApiResponseDTO.onSuccess(resultDTO);
+        //memberQueryService.findMemberById(auth.id()).getTown()
     }
 
     @GetMapping("/api/keywords/recent")

--- a/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,7 +58,7 @@ public class KeywordController {
         return ApiResponseDTO.onSuccess(resultDTO);
     }
 
-    @GetMapping("/api/keywords/{keyword}/delete")
+    @DeleteMapping("/api/keywords/{keyword}")
     @Operation(
             summary = "사용자의 최근 검색어 삭제",
             description = "사용자가 본인의 최근 검색어를 삭제합니다."

--- a/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
@@ -71,7 +71,7 @@ public class KeywordController {
             @AuthenticationPrincipal AuthInfoDTO auth,
             @PathVariable("keyword") String keyword
     ) {
-        DeleteKeywordResult deleteKeywordResult = keywordCommandService.deleteRecentKeyword(auth.id(), keyword);
+        DeleteKeywordResult deleteKeywordResult = keywordCommandService.deleteMemberKeyword(auth.id(), keyword);
         return ApiResponseDTO.onSuccess(deleteKeywordResult);
     }
 

--- a/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import site.moamoa.backend.api_payload.ApiResponseDTO;
 import site.moamoa.backend.service.component.command.keyword.KeywordCommandService;
 import site.moamoa.backend.service.component.query.keyword.KeywordQueryService;
-import site.moamoa.backend.service.component.query.member.MemberQueryService;
+import site.moamoa.backend.service.module.member.MemberModuleServiceImpl;
 import site.moamoa.backend.web.dto.base.AuthInfoDTO;
 
 import static site.moamoa.backend.web.dto.response.KeywordResponseDTO.DeleteKeywordResult;
@@ -26,7 +26,7 @@ public class KeywordController {
 
     private final KeywordCommandService keywordCommandService;
     private final KeywordQueryService keywordQueryService;
-    private final MemberQueryService memberQueryService;
+    private final MemberModuleServiceImpl memberQueryService;
 
     @GetMapping("/api/keywords/ranking")
     @Operation(

--- a/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/KeywordController.java
@@ -58,7 +58,7 @@ public class KeywordController {
         return ApiResponseDTO.onSuccess(resultDTO);
     }
 
-    @GetMapping("/api/keywords/{keyword}")
+    @GetMapping("/api/keywords/{keyword}/delete")
     @Operation(
             summary = "사용자의 최근 검색어 삭제",
             description = "사용자가 본인의 최근 검색어를 삭제합니다."

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import site.moamoa.backend.api_payload.ApiResponseDTO;
+import site.moamoa.backend.service.component.command.keyword.KeywordCommandServiceImpl;
 import site.moamoa.backend.service.component.command.post.PostCommandService;
 import site.moamoa.backend.service.component.query.post.PostQueryService;
 import site.moamoa.backend.web.dto.base.AuthInfoDTO;
@@ -33,6 +34,7 @@ public class PostController {
 
     private final PostQueryService postQueryService;
     private final PostCommandService postCommandService;
+    private final KeywordCommandServiceImpl keywordCommandService;
 
     @GetMapping("/api/posts/ranking")
     @Operation(
@@ -217,7 +219,7 @@ public class PostController {
             @RequestParam(value = "maxPrice", required = false) final Integer maxPrice
     ) {
         if (!keyword.isEmpty()) {
-            postCommandService.updateKeywordCount(auth.id(), keyword);
+            keywordCommandService.updateKeywordCount(auth.id(), keyword);
         }
         GetPosts resultDTO = postQueryService.findPostsByConditions(keyword, categoryId, dDay, total, minPrice, maxPrice);
         return ApiResponseDTO.onSuccess(resultDTO);

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -219,7 +219,8 @@ public class PostController {
             @RequestParam(value = "maxPrice", required = false) final Integer maxPrice
     ) {
         if (!keyword.isEmpty()) {
-            keywordCommandService.updateKeywordCount(auth.id(), keyword);
+            keywordCommandService.addMemberKeyword(auth.id(), keyword);
+            keywordCommandService.updateTownKeywordCount(auth.id(), keyword);
         }
         GetPosts resultDTO = postQueryService.findPostsByConditions(keyword, categoryId, dDay, total, minPrice, maxPrice);
         return ApiResponseDTO.onSuccess(resultDTO);

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -2,7 +2,6 @@ package site.moamoa.backend.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactor/32

### 💡 작업동기
- updateKeywordCount 메소드 기능 직관적인 파악이 어려움
- 검색어 삭제 API에 삭제 관련 기능 반영 안됨


### 🔑 주요 변경사항
- updateKeywordCount 메소드를 addMemberKeyword, updateTownKeyword로 분리
- 검색어 삭제 API를 "/api/keywords/{keyword}/delete"로 변경

### 관련 이슈
- https://github.com/moa-moa-service/moamoa-backend/issues/32