### PR TITLE
🐛 Fix: 공동구매 수정 요청 시, 수정 사항과 이미지를 분리하여 요청 가능하게 개선

### DIFF
--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -113,9 +113,9 @@ public class PostController {
         return ApiResponseDTO.onSuccess(resultDTO);
     }
 
-    @PatchMapping("/api/posts/{postId}")
+    @PatchMapping(value = "/api/posts/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(
-            summary = "공동구매 상세정보 수정 (수정중)",
+            summary = "공동구매 상세정보 수정",
             description = "공동구매 정보를 받아 기존의 공동구매 게시글을 수정합니다."
     )
     @ApiResponses(value = {

--- a/src/main/java/site/moamoa/backend/web/dto/request/PostRequestDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/request/PostRequestDTO.java
@@ -4,12 +4,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-
 import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.web.multipart.MultipartFile;
 import site.moamoa.backend.domain.embedded.Address;
 
 public class PostRequestDTO {
@@ -34,15 +29,13 @@ public class PostRequestDTO {
     ) {
     }
 
-    public record UpdatePostInfo(
+    public record  UpdatePostInfo(
             Long categoryId,
             @Min(value = 1, message = "최소 1명 이상이어야 합니다.")
             @Max(value = 10, message = "최대 10명까지만 허용됩니다.")
             Integer personnel,
             @Future(message = "현재 날짜 이후의 날짜여야 합니다.")
             LocalDateTime deadline,
-            @Size(max = 10, message = "이미지는 최대 10개까지만 허용됩니다.")
-            List<MultipartFile> image,
             Address dealLocation,
             String productName,
             Integer price,


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/63

### 💡 작업동기
- 공동구매 수정 요청 시, 수정 사항과 이미지가 분리되지 않아 요청 시 각각 추가할 수 없는 문제 발생 

### 🔑 주요 변경사항
- 공동구매 수정 API의 요청 바디에서 수정 사항과 이미지를 분리하여 각각 추가할 수 있게함.

### 관련 이슈
https://github.com/moa-moa-service/moamoa-backend/issues/63