### PR TITLE
🐛 Fix: 공동구매 상태변경 시, 모집 중으로 상태변경 기능 추가

### DIFF
--- a/src/main/java/site/moamoa/backend/domain/Post.java
+++ b/src/main/java/site/moamoa/backend/domain/Post.java
@@ -74,8 +74,11 @@ public class Post extends BaseEntity {
         this.description = Optional.ofNullable(request.description()).orElse(this.description);
     }
 
-    public void updateStatusToFull() {
-        this.capacityStatus = CapacityStatus.FULL;
+    public void updateStatus() {
+        if (this.capacityStatus == CapacityStatus.NOT_FULL)
+            this.capacityStatus = CapacityStatus.FULL;
+        else if (this.capacityStatus == CapacityStatus.FULL)
+            this.capacityStatus = CapacityStatus.NOT_FULL;
     }
 
     public void updateViewCount() {

--- a/src/main/java/site/moamoa/backend/domain/Post.java
+++ b/src/main/java/site/moamoa/backend/domain/Post.java
@@ -74,11 +74,8 @@ public class Post extends BaseEntity {
         this.description = Optional.ofNullable(request.description()).orElse(this.description);
     }
 
-    public void updateStatus() {
-        if (this.capacityStatus == CapacityStatus.NOT_FULL)
-            this.capacityStatus = CapacityStatus.FULL;
-        else if (this.capacityStatus == CapacityStatus.FULL)
-            this.capacityStatus = CapacityStatus.NOT_FULL;
+    public void updateStatusToFull() {
+        this.capacityStatus = CapacityStatus.FULL;
     }
 
     public void updateViewCount() {

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -62,7 +62,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     public UpdatePostStatusResult updatePostStatus(Long memberId, Long postId) {
         memberPostModuleService.validMemberPostIsAuthor(memberId, postId);
         Post updatePost = postModuleService.findPostById(postId);
-        updatePost.updateStatusToFull();
+        updatePost.updateStatus();
         return PostConverter.toUpdatePostStatusResult(updatePost);
     }
 

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -62,7 +62,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     public UpdatePostStatusResult updatePostStatus(Long memberId, Long postId) {
         memberPostModuleService.validMemberPostIsAuthor(memberId, postId);
         Post updatePost = postModuleService.findPostById(postId);
-        updatePost.updateStatus();
+        updatePost.updateStatusToFull();
         return PostConverter.toUpdatePostStatusResult(updatePost);
     }
 

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -136,7 +136,7 @@ public class PostController {
 
     @PatchMapping("/api/posts/{postId}/status")
     @Operation(
-            summary = "공동구매 상태 변경 (수정중)",
+            summary = "공동구매 상태 변경",
             description = "기존의 공동구매 상태를 변경합니다."
     )
     @ApiResponses(value = {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/64

### 💡 작업동기
- 공동구매 상태변경 시, 모집 완료로만 상태변경이 가능하고, 모집중으로는 변경불가능한 문제 발생.

### 🔑 주요 변경사항
- 공동구매 상태변경 시, 모집 중이면 모집 완료로 변경, 모집 완료면 모집 중으로 변경하게끔 수정. 

### 관련 이슈
https://github.com/moa-moa-service/moamoa-backend/issues/64