### PR TITLE
:ambulance: Hotfix: jpa.hibernate.ddl-auto 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,8 +52,8 @@ spring:
       max-request-size: 30MB
   data:
     redis:
-      host: ${develop.redis.host}
-      port: ${develop.redis.port}
+      host: ${local.redis.host}
+      port: ${local.redis.port}
   datasource:
     url: ${local.mysql.url}
     username: ${local.mysql.username}
@@ -111,10 +111,11 @@ spring:
     password: ${develop.mysql.password}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
+    hibernate:
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 100
-        ddl-auto: create
 
   security:
     oauth2:
@@ -172,7 +173,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feature/52

### 💡 작업동기
- JPA 테이블이 생성되지 않는 문제가 있습니다.
- Local 환경의 Redis 매핑에 문제가 있습니다.

### 🔑 주요 변경사항
- 테이블을 생성할 수 있도록 `jpa.hibernate.ddl-auto`에 옵션을 만들도록 변경했습니다.