### PR TITLE
🐛 Fix: 공동구매 참여 시, 게시물 주최자는 참여할 수 없게끔 개선

### DIFF
--- a/src/main/java/site/moamoa/backend/api_payload/code/status/ErrorStatus.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Member-Post
     MEMBER_IS_NOT_AUTHOR(HttpStatus.FORBIDDEN, "MEMBER_POST403", "해당 멤버에게는 금지된 요청입니다."),
     MEMBER_POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_POST404", "공동구매 참여 기록이 없습니다."),
+    AUTHOR_CAN_NOT_BE_PARTICIPATOR(HttpStatus.FORBIDDEN, "MEMBER_POST4003", "글쓴이는 참여자가 될 수 없습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 사용자를 찾을 수 없습니다."),

--- a/src/main/java/site/moamoa/backend/api_payload/code/status/ErrorStatus.java
+++ b/src/main/java/site/moamoa/backend/api_payload/code/status/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Member-Post
     MEMBER_IS_NOT_AUTHOR(HttpStatus.FORBIDDEN, "MEMBER_POST403", "해당 멤버에게는 금지된 요청입니다."),
     MEMBER_POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_POST404", "공동구매 참여 기록이 없습니다."),
-    AUTHOR_CAN_NOT_BE_PARTICIPATOR(HttpStatus.FORBIDDEN, "MEMBER_POST4003", "글쓴이는 참여자가 될 수 없습니다."),
+    MEMBER_CAN_NOT_BE_PARTICIPATOR(HttpStatus.FORBIDDEN, "MEMBER_POST4003", "해당 멤버는 참여자가 될 수 없습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 사용자를 찾을 수 없습니다."),

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
@@ -11,4 +11,6 @@ public interface MemberPostQueryDSLRepository {
     Member findPostAdminByPostId(Long postId);
 
     List<Post> findPostsByRecruitingAndParticipating(Long memberId, IsAuthorStatus isAuthorStatus, CapacityStatus capacityStatus);
+
+    boolean isMemberAuthorOfPost(Member member, Post post);
 }

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
@@ -12,5 +12,5 @@ public interface MemberPostQueryDSLRepository {
 
     List<Post> findPostsByRecruitingAndParticipating(Long memberId, IsAuthorStatus isAuthorStatus, CapacityStatus capacityStatus);
 
-    boolean isMemberAuthorOfPost(Member member, Post post);
+    boolean existsByMemberIdAndPostId(Long memberId, Long postId);
 }

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepositoryImpl.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepositoryImpl.java
@@ -49,17 +49,14 @@ public class MemberPostQueryDSLRepositoryImpl implements MemberPostQueryDSLRepos
     }
 
     @Override
-    public boolean isMemberAuthorOfPost(Member member, Post post) {
+    public boolean existsByMemberIdAndPostId(Long memberId, Long postId) {
         QMemberPost memberPost = QMemberPost.memberPost;
 
-        Integer count = jpaQueryFactory
-            .selectOne()
+        return jpaQueryFactory.selectOne()
             .from(memberPost)
-            .where(memberPost.member.eq(member)
-                .and(memberPost.post.eq(post))
-                .and(memberPost.isAuthorStatus.eq(IsAuthorStatus.AUTHOR)))
-            .fetchFirst();
-        return count != null && count > 0;
+            .where(memberPost.member.id.eq(memberId)
+                .and(memberPost.post.id.eq(postId)))
+            .fetchFirst() != null;
     }
 
     private void addCondition(BooleanBuilder builder, BooleanExpression condition) {

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepositoryImpl.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepositoryImpl.java
@@ -48,6 +48,20 @@ public class MemberPostQueryDSLRepositoryImpl implements MemberPostQueryDSLRepos
                 .fetch();
     }
 
+    @Override
+    public boolean isMemberAuthorOfPost(Member member, Post post) {
+        QMemberPost memberPost = QMemberPost.memberPost;
+
+        Integer count = jpaQueryFactory
+            .selectOne()
+            .from(memberPost)
+            .where(memberPost.member.eq(member)
+                .and(memberPost.post.eq(post))
+                .and(memberPost.isAuthorStatus.eq(IsAuthorStatus.AUTHOR)))
+            .fetchFirst();
+        return count != null && count > 0;
+    }
+
     private void addCondition(BooleanBuilder builder, BooleanExpression condition) {
         builder.and(condition);
     }

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import site.moamoa.backend.api_payload.code.status.ErrorStatus;
-import site.moamoa.backend.api_payload.exception.handler.MemberPostHandler;
 import site.moamoa.backend.converter.MemberPostConverter;
 import site.moamoa.backend.converter.PostConverter;
 import site.moamoa.backend.converter.PostImageConverter;
@@ -46,17 +44,12 @@ public class PostCommandServiceImpl implements PostCommandService {
     public AddPostResult registerPost(Long memberId, AddPost addPost, List<MultipartFile> images) {
         Category category = categoryModuleService.findCategoryById(addPost.categoryId());
         List<PostImage> postImages = PostImageConverter.toPostImages(images, amazonS3Manager);
-
         Post newPost = PostConverter.toPost(addPost, category, postImages);
         postImages.forEach(postImage -> postImage.setPost(newPost));
-
         postModuleService.savePost(newPost);
-
         Member authMember = memberModuleService.findMemberById(memberId);
         MemberPost newMemberPost = MemberPostConverter.toMemberPostAsAuthor(newPost, authMember);
-
         memberPostModuleService.saveMemberPost(newMemberPost);
-
         return PostConverter.toAddPostResult(newPost);
     }
 
@@ -88,9 +81,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     public AddMemberPostResult joinPost(Long memberId, Long postId) {
         Member authMember = memberModuleService.findMemberById(memberId);
         Post joinPost = postModuleService.findPostById(postId);
-        if (memberPostModuleService.IsPostAuthor(authMember, joinPost))
-            throw new MemberPostHandler(ErrorStatus.AUTHOR_CAN_NOT_BE_PARTICIPATOR);
-
+        memberPostModuleService.checkMemberPostExists(memberId, postId);
         MemberPost newMemberPost = MemberPostConverter.toMemberPostAsParticipator(joinPost, authMember);
         memberPostModuleService.saveMemberPost(newMemberPost);
         return MemberPostConverter.toAddMemberPostResult(newMemberPost);

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import site.moamoa.backend.api_payload.code.status.ErrorStatus;
+import site.moamoa.backend.api_payload.exception.handler.MemberPostHandler;
 import site.moamoa.backend.converter.MemberPostConverter;
 import site.moamoa.backend.converter.PostConverter;
 import site.moamoa.backend.converter.PostImageConverter;
@@ -86,6 +88,9 @@ public class PostCommandServiceImpl implements PostCommandService {
     public AddMemberPostResult joinPost(Long memberId, Long postId) {
         Member authMember = memberModuleService.findMemberById(memberId);
         Post joinPost = postModuleService.findPostById(postId);
+        if (memberPostModuleService.IsPostAuthor(authMember, joinPost))
+            throw new MemberPostHandler(ErrorStatus.AUTHOR_CAN_NOT_BE_PARTICIPATOR);
+
         MemberPost newMemberPost = MemberPostConverter.toMemberPostAsParticipator(joinPost, authMember);
         memberPostModuleService.saveMemberPost(newMemberPost);
         return MemberPostConverter.toAddMemberPostResult(newMemberPost);

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
@@ -21,6 +21,6 @@ public interface MemberPostModuleService {
   
     List<Post> findPostsByRecruitingAndParticipating(Long memberId, IsAuthorStatus isAuthorStatus, CapacityStatus capacityStatus);
 
-    boolean IsPostAuthor(Member authMember, Post post);
+    void checkMemberPostExists(Long memberId, Long postId);
 }
 

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
@@ -20,5 +20,7 @@ public interface MemberPostModuleService {
     void deleteMemberPost(Long id);
   
     List<Post> findPostsByRecruitingAndParticipating(Long memberId, IsAuthorStatus isAuthorStatus, CapacityStatus capacityStatus);
+
+    boolean IsPostAuthor(Member authMember, Post post);
 }
 

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
@@ -58,7 +58,8 @@ public class MemberPostModuleServiceImpl implements MemberPostModuleService {
     }
 
     @Override
-    public boolean IsPostAuthor(Member authMember, Post post) {
-        return memberPostRepository.isMemberAuthorOfPost(authMember, post);
+    public void checkMemberPostExists(Long memberId, Long postId) {
+        if (memberPostRepository.existsByMemberIdAndPostId(memberId, postId))
+            throw new MemberPostHandler(ErrorStatus.MEMBER_CAN_NOT_BE_PARTICIPATOR);
     }
 }

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
@@ -56,4 +56,9 @@ public class MemberPostModuleServiceImpl implements MemberPostModuleService {
     public void deleteMemberPost(Long id) {
         memberPostRepository.deleteById(id);
     }
+
+    @Override
+    public boolean IsPostAuthor(Member authMember, Post post) {
+        return memberPostRepository.isMemberAuthorOfPost(authMember, post);
+    }
 }

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -98,7 +98,7 @@ public class PostController {
 
     @PostMapping(value = "/api/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(
-            summary = "공동구매 등록 (수정중)",
+            summary = "공동구매 등록",
             description = "공동구매 정보를 받아 새로운 공동구매 게시글을 등록합니다."
     )
     @ApiResponses(value = {
@@ -115,7 +115,7 @@ public class PostController {
 
     @PatchMapping("/api/posts/{postId}")
     @Operation(
-            summary = "공동구매 상세정보 수정 (수정중)",
+            summary = "공동구매 상세정보 수정",
             description = "공동구매 정보를 받아 기존의 공동구매 게시글을 수정합니다."
     )
     @ApiResponses(value = {
@@ -136,7 +136,7 @@ public class PostController {
 
     @PatchMapping("/api/posts/{postId}/status")
     @Operation(
-            summary = "공동구매 상태 변경 (수정중)",
+            summary = "공동구매 상태 변경",
             description = "기존의 공동구매 상태를 변경합니다."
     )
     @ApiResponses(value = {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/65

### 💡 작업동기
- 게시물 주최자가 해당 게시물에 참여자로 참가할 수 있는 문제 발생

### 🔑 주요 변경사항
- 주최자가 본인이 주최한 게시물에 참여하려고 할 때, 예외 처리 로직 구현 

### 관련 이슈
https://github.com/moa-moa-service/moamoa-backend/issues/65