### PR TITLE
✨ Feat: 알림 생성, 조회 기능 구현 

### DIFF
--- a/src/main/generated/site/moamoa/backend/domain/QCategory.java
+++ b/src/main/generated/site/moamoa/backend/domain/QCategory.java
@@ -1,0 +1,47 @@
+package site.moamoa.backend.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCategory is a Querydsl query type for Category
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCategory extends EntityPathBase<Category> {
+
+    private static final long serialVersionUID = -1205894425L;
+
+    public static final QCategory category = new QCategory("category");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QCategory(String variable) {
+        super(Category.class, forVariable(variable));
+    }
+
+    public QCategory(Path<? extends Category> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCategory(PathMetadata metadata) {
+        super(Category.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/QComment.java
+++ b/src/main/generated/site/moamoa/backend/domain/QComment.java
@@ -1,0 +1,69 @@
+package site.moamoa.backend.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = -1722529962L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    public final ListPath<Comment, QComment> children = this.<Comment, QComment>createList("children", Comment.class, QComment.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    public final QNotice notice;
+
+    public final QComment parent;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member"), inits.get("member")) : null;
+        this.notice = inits.isInitialized("notice") ? new QNotice(forProperty("notice"), inits.get("notice")) : null;
+        this.parent = inits.isInitialized("parent") ? new QComment(forProperty("parent"), inits.get("parent")) : null;
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/QMember.java
+++ b/src/main/generated/site/moamoa/backend/domain/QMember.java
@@ -1,0 +1,73 @@
+package site.moamoa.backend.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 637122243L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMember member = new QMember("member1");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    public final site.moamoa.backend.domain.embedded.QAddress address;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final EnumPath<site.moamoa.backend.domain.enums.DeletionStatus> deletionStatus = createEnum("deletionStatus", site.moamoa.backend.domain.enums.DeletionStatus.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath profileImage = createString("profileImage");
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    public final EnumPath<site.moamoa.backend.domain.enums.RoleType> roleType = createEnum("roleType", site.moamoa.backend.domain.enums.RoleType.class);
+
+    public final StringPath socialId = createString("socialId");
+
+    public final StringPath town = createString("town");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMember(String variable) {
+        this(Member.class, forVariable(variable), INITS);
+    }
+
+    public QMember(Path<? extends Member> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMember(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMember(PathMetadata metadata, PathInits inits) {
+        this(Member.class, metadata, inits);
+    }
+
+    public QMember(Class<? extends Member> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new site.moamoa.backend.domain.embedded.QAddress(forProperty("address")) : null;
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/QNotice.java
+++ b/src/main/generated/site/moamoa/backend/domain/QNotice.java
@@ -1,0 +1,67 @@
+package site.moamoa.backend.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotice is a Querydsl query type for Notice
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotice extends EntityPathBase<Notice> {
+
+    private static final long serialVersionUID = 675201793L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotice notice = new QNotice("notice");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    public final ListPath<Comment, QComment> commentList = this.<Comment, QComment>createList("commentList", Comment.class, QComment.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageUrl = createString("imageUrl");
+
+    public final QPost post;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QNotice(String variable) {
+        this(Notice.class, forVariable(variable), INITS);
+    }
+
+    public QNotice(Path<? extends Notice> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotice(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotice(PathMetadata metadata, PathInits inits) {
+        this(Notice.class, metadata, inits);
+    }
+
+    public QNotice(Class<? extends Notice> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/QNotification.java
+++ b/src/main/generated/site/moamoa/backend/domain/QNotification.java
@@ -1,0 +1,67 @@
+package site.moamoa.backend.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = -813682092L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    public final StringPath message = createString("message");
+
+    public final NumberPath<Long> referenceId = createNumber("referenceId", Long.class);
+
+    public final EnumPath<site.moamoa.backend.domain.enums.NotificationStatus> status = createEnum("status", site.moamoa.backend.domain.enums.NotificationStatus.class);
+
+    public final EnumPath<site.moamoa.backend.domain.enums.NotificationType> type = createEnum("type", site.moamoa.backend.domain.enums.NotificationType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/QPost.java
+++ b/src/main/generated/site/moamoa/backend/domain/QPost.java
@@ -1,0 +1,86 @@
+package site.moamoa.backend.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPost is a Querydsl query type for Post
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPost extends EntityPathBase<Post> {
+
+    private static final long serialVersionUID = 1533721353L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPost post = new QPost("post");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    public final NumberPath<Integer> available = createNumber("available", Integer.class);
+
+    public final EnumPath<site.moamoa.backend.domain.enums.CapacityStatus> capacityStatus = createEnum("capacityStatus", site.moamoa.backend.domain.enums.CapacityStatus.class);
+
+    public final QCategory category;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deadline = createDateTime("deadline", java.time.LocalDateTime.class);
+
+    public final site.moamoa.backend.domain.embedded.QAddress dealLocation;
+
+    public final StringPath dealTown = createString("dealTown");
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<Notice, QNotice> noticeList = this.<Notice, QNotice>createList("noticeList", Notice.class, QNotice.class, PathInits.DIRECT2);
+
+    public final NumberPath<Integer> personnel = createNumber("personnel", Integer.class);
+
+    public final ListPath<site.moamoa.backend.domain.mapping.PostImage, site.moamoa.backend.domain.mapping.QPostImage> postImages = this.<site.moamoa.backend.domain.mapping.PostImage, site.moamoa.backend.domain.mapping.QPostImage>createList("postImages", site.moamoa.backend.domain.mapping.PostImage.class, site.moamoa.backend.domain.mapping.QPostImage.class, PathInits.DIRECT2);
+
+    public final StringPath productName = createString("productName");
+
+    public final NumberPath<Integer> totalPrice = createNumber("totalPrice", Integer.class);
+
+    public final StringPath town = createString("town");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final NumberPath<Integer> viewCount = createNumber("viewCount", Integer.class);
+
+    public QPost(String variable) {
+        this(Post.class, forVariable(variable), INITS);
+    }
+
+    public QPost(Path<? extends Post> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPost(PathMetadata metadata, PathInits inits) {
+        this(Post.class, metadata, inits);
+    }
+
+    public QPost(Class<? extends Post> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.category = inits.isInitialized("category") ? new QCategory(forProperty("category")) : null;
+        this.dealLocation = inits.isInitialized("dealLocation") ? new site.moamoa.backend.domain.embedded.QAddress(forProperty("dealLocation")) : null;
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/common/QBaseEntity.java
+++ b/src/main/generated/site/moamoa/backend/domain/common/QBaseEntity.java
@@ -1,0 +1,39 @@
+package site.moamoa.backend.domain.common;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 1349076590L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/embedded/QAddress.java
+++ b/src/main/generated/site/moamoa/backend/domain/embedded/QAddress.java
@@ -1,0 +1,41 @@
+package site.moamoa.backend.domain.embedded;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAddress is a Querydsl query type for Address
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAddress extends BeanPath<Address> {
+
+    private static final long serialVersionUID = -1202471623L;
+
+    public static final QAddress address = new QAddress("address");
+
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
+    public final StringPath name = createString("name");
+
+    public QAddress(String variable) {
+        super(Address.class, forVariable(variable));
+    }
+
+    public QAddress(Path<? extends Address> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAddress(PathMetadata metadata) {
+        super(Address.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/mapping/QMemberPost.java
+++ b/src/main/generated/site/moamoa/backend/domain/mapping/QMemberPost.java
@@ -1,0 +1,64 @@
+package site.moamoa.backend.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberPost is a Querydsl query type for MemberPost
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberPost extends EntityPathBase<MemberPost> {
+
+    private static final long serialVersionUID = 2030905891L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberPost memberPost = new QMemberPost("memberPost");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<site.moamoa.backend.domain.enums.IsAuthorStatus> isAuthorStatus = createEnum("isAuthorStatus", site.moamoa.backend.domain.enums.IsAuthorStatus.class);
+
+    public final site.moamoa.backend.domain.QMember member;
+
+    public final site.moamoa.backend.domain.QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMemberPost(String variable) {
+        this(MemberPost.class, forVariable(variable), INITS);
+    }
+
+    public QMemberPost(Path<? extends MemberPost> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberPost(PathMetadata metadata, PathInits inits) {
+        this(MemberPost.class, metadata, inits);
+    }
+
+    public QMemberPost(Class<? extends MemberPost> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new site.moamoa.backend.domain.QMember(forProperty("member"), inits.get("member")) : null;
+        this.post = inits.isInitialized("post") ? new site.moamoa.backend.domain.QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/site/moamoa/backend/domain/mapping/QPostImage.java
+++ b/src/main/generated/site/moamoa/backend/domain/mapping/QPostImage.java
@@ -1,0 +1,61 @@
+package site.moamoa.backend.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPostImage is a Querydsl query type for PostImage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPostImage extends EntityPathBase<PostImage> {
+
+    private static final long serialVersionUID = 151549874L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPostImage postImage = new QPostImage("postImage");
+
+    public final site.moamoa.backend.domain.common.QBaseEntity _super = new site.moamoa.backend.domain.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final site.moamoa.backend.domain.QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath url = createString("url");
+
+    public QPostImage(String variable) {
+        this(PostImage.class, forVariable(variable), INITS);
+    }
+
+    public QPostImage(Path<? extends PostImage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPostImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPostImage(PathMetadata metadata, PathInits inits) {
+        this(PostImage.class, metadata, inits);
+    }
+
+    public QPostImage(Class<? extends PostImage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new site.moamoa.backend.domain.QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
+++ b/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
@@ -1,0 +1,34 @@
+package site.moamoa.backend.converter;
+
+import site.moamoa.backend.domain.Notification;
+import site.moamoa.backend.domain.enums.NotificationStatus;
+import site.moamoa.backend.domain.enums.NotificationType;
+import site.moamoa.backend.web.dto.base.NotificationDTO;
+import site.moamoa.backend.web.dto.base.SimplePostDTO;
+import site.moamoa.backend.web.dto.response.NotificationResponseDTO;
+import site.moamoa.backend.web.dto.response.PostResponseDTO;
+
+import java.util.List;
+
+public class NotificationConverter {
+    public static NotificationDTO toNotificationDTO(Notification notification) {
+        return NotificationDTO.builder()
+                .notificationId(notification.getId())
+                .message(notification.getMessage())
+                .type(notification.getType())
+                .status(notification.getStatus())
+                .build();
+    }
+
+    public static NotificationResponseDTO.GetNotification toGetNotification(NotificationDTO notificationDTO) {
+        return NotificationResponseDTO.GetNotification.builder()
+                .notificationDTO(notificationDTO)
+                .build();
+    }
+
+    public static PostResponseDTO.GetPosts toGetPosts(List<SimplePostDTO> dtoList) {
+        return PostResponseDTO.GetPosts.builder()
+                .SimplePostDtoList(dtoList)
+                .build();
+    }
+}

--- a/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
+++ b/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
@@ -16,7 +16,9 @@ public class NotificationConverter {
                 .notificationId(notification.getId())
                 .message(notification.getMessage())
                 .type(notification.getType())
+                .referenceId(notification.getReferenceId())
                 .status(notification.getStatus())
+                .createdAt(notification.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
+++ b/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
@@ -1,8 +1,6 @@
 package site.moamoa.backend.converter;
 
 import site.moamoa.backend.domain.Notification;
-import site.moamoa.backend.domain.enums.NotificationStatus;
-import site.moamoa.backend.domain.enums.NotificationType;
 import site.moamoa.backend.web.dto.base.NotificationDTO;
 import site.moamoa.backend.web.dto.base.SimplePostDTO;
 import site.moamoa.backend.web.dto.response.NotificationResponseDTO;
@@ -15,7 +13,7 @@ public class NotificationConverter {
         return NotificationDTO.builder()
                 .notificationId(notification.getId())
                 .message(notification.getMessage())
-                .type(notification.getType())
+                .type(notification.getType().getBelongingTo())
                 .referenceId(notification.getReferenceId())
                 .status(notification.getStatus())
                 .createdAt(notification.getCreatedAt())

--- a/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
+++ b/src/main/java/site/moamoa/backend/converter/NotificationConverter.java
@@ -22,9 +22,9 @@ public class NotificationConverter {
                 .build();
     }
 
-    public static NotificationResponseDTO.GetNotification toGetNotification(NotificationDTO notificationDTO) {
-        return NotificationResponseDTO.GetNotification.builder()
-                .notificationDTO(notificationDTO)
+    public static NotificationResponseDTO.GetNotifications toGetNotifications(List<NotificationDTO> dtoList) {
+        return NotificationResponseDTO.GetNotifications.builder()
+                .notificationDTOList(dtoList)
                 .build();
     }
 

--- a/src/main/java/site/moamoa/backend/converter/PostConverter.java
+++ b/src/main/java/site/moamoa/backend/converter/PostConverter.java
@@ -8,6 +8,7 @@ import site.moamoa.backend.domain.mapping.PostImage;
 import site.moamoa.backend.web.dto.base.MemberDTO;
 import site.moamoa.backend.web.dto.base.PostDTO;
 import site.moamoa.backend.web.dto.base.SimplePostDTO;
+import site.moamoa.backend.web.dto.base.SimplePostDtoWithAddress;
 import site.moamoa.backend.web.dto.request.PostRequestDTO;
 import site.moamoa.backend.web.dto.response.MemberResponseDTO;
 import site.moamoa.backend.web.dto.response.NoticeResponseDTO;
@@ -34,10 +35,24 @@ public class PostConverter {
                 .build();
     }
 
+    public static SimplePostDtoWithAddress toSimplePostDtoWithAddress(Post post, List<PostImage> postImages) {
+
+        return SimplePostDtoWithAddress.builder()
+            .simplePostDTO(toSimplePostDTO(post, postImages))
+            .address(post.getDealLocation())
+            .build();
+    }
+
     public static PostResponseDTO.GetPosts toGetPosts(List<SimplePostDTO> dtoList) {
         return PostResponseDTO.GetPosts.builder()
                 .SimplePostDtoList(dtoList)
                 .build();
+    }
+
+    public static PostResponseDTO.GetPostsWithAddress toGetPostsWithAddress(List<SimplePostDtoWithAddress> dtoList) {
+        return PostResponseDTO.GetPostsWithAddress.builder()
+            .SimplePostDtoList(dtoList)
+            .build();
     }
 
     public static PostDTO toPostDTO(Post post, List<PostImage> postImageList, Category category) {
@@ -52,6 +67,7 @@ public class PostConverter {
                 .productName(post.getProductName())
                 .personnel(personnel)
                 .dealTown(post.getDealTown())
+                .town(post.getTown())
                 .viewCount(post.getViewCount())
                 .available(post.getAvailable())
                 .price(post.getTotalPrice() / personnel)
@@ -119,6 +135,7 @@ public class PostConverter {
                 .postImages(postImages)
                 .dealLocation(addPost.dealLocation())
                 .dealTown(addPost.dealTown())
+                .town(addPost.town())
                 .totalPrice(addPost.price())
                 .description(addPost.description())
                 .build();

--- a/src/main/java/site/moamoa/backend/domain/Notification.java
+++ b/src/main/java/site/moamoa/backend/domain/Notification.java
@@ -1,0 +1,27 @@
+package site.moamoa.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.moamoa.backend.domain.enums.NotificationStatus;
+import site.moamoa.backend.domain.enums.NotificationType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String message;
+    private NotificationType type; //NEW_PARTICIPATION, QUANTITY_FULFILL, NEW_NOTICE, NEW_COMMENT
+    private Long referenceId; // postId or noticeId
+    private NotificationStatus status; // READ, UNREAD
+}

--- a/src/main/java/site/moamoa/backend/domain/Notification.java
+++ b/src/main/java/site/moamoa/backend/domain/Notification.java
@@ -10,7 +10,7 @@ import site.moamoa.backend.domain.enums.NotificationType;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Notification {
+public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")

--- a/src/main/java/site/moamoa/backend/domain/Notification.java
+++ b/src/main/java/site/moamoa/backend/domain/Notification.java
@@ -2,6 +2,7 @@ package site.moamoa.backend.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import site.moamoa.backend.domain.common.BaseEntity;
 import site.moamoa.backend.domain.enums.NotificationStatus;
 import site.moamoa.backend.domain.enums.NotificationType;
 

--- a/src/main/java/site/moamoa/backend/domain/Post.java
+++ b/src/main/java/site/moamoa/backend/domain/Post.java
@@ -74,11 +74,12 @@ public class Post extends BaseEntity {
         this.description = Optional.ofNullable(request.description()).orElse(this.description);
     }
 
-    public void updateStatus() {
-        if (this.capacityStatus == CapacityStatus.NOT_FULL)
-            this.capacityStatus = CapacityStatus.FULL;
-        else if (this.capacityStatus == CapacityStatus.FULL)
-            this.capacityStatus = CapacityStatus.NOT_FULL;
+    public void updateStatusToNotFull() {
+        this.capacityStatus = CapacityStatus.NOT_FULL;
+    }
+
+    public void updateStatusToFull() {
+        this.capacityStatus = CapacityStatus.FULL;
     }
 
     public void updateViewCount() {

--- a/src/main/java/site/moamoa/backend/domain/Post.java
+++ b/src/main/java/site/moamoa/backend/domain/Post.java
@@ -38,7 +38,9 @@ public class Post extends BaseEntity {
     @Embedded
     private Address dealLocation; // 상품 거래 장소(상세 주소) ex. 동작구 상도동 CU
 
-    private String dealTown; // 상품 거래 동네 ex. 상도동
+    private String dealTown; // 상품 거래 주소 ex. OO역 OO출구 앞
+    
+    private String town;  // 상품 거래 동네 ex. 상도동
 
     private Integer totalPrice; //상품 총 가격
 

--- a/src/main/java/site/moamoa/backend/domain/enums/NotificationStatus.java
+++ b/src/main/java/site/moamoa/backend/domain/enums/NotificationStatus.java
@@ -1,5 +1,11 @@
 package site.moamoa.backend.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum NotificationStatus {
-    READ, UNREAD
+  READ,
+  UNREAD
 }

--- a/src/main/java/site/moamoa/backend/domain/enums/NotificationStatus.java
+++ b/src/main/java/site/moamoa/backend/domain/enums/NotificationStatus.java
@@ -1,0 +1,5 @@
+package site.moamoa.backend.domain.enums;
+
+public enum NotificationStatus {
+    READ, UNREAD
+}

--- a/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
+++ b/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
@@ -1,5 +1,15 @@
 package site.moamoa.backend.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum NotificationType {
-    NEW_PARTICIPATION, QUANTITY_FULFILL, NEW_NOTICE, NEW_COMMENT
+  NEW_COMMENT("notice"),
+  NEW_PARTICIPATION("post"),
+  NEW_NOTICE("notice"),
+  QUANTITY_FULLFIL("post");
+
+  private final String belongingTo;
 }

--- a/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
+++ b/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
@@ -1,0 +1,5 @@
+package site.moamoa.backend.domain.enums;
+
+public enum NotificationType {
+    NEW_PARTICIPATION, QUANTITY_FULFILL, NEW_NOTICE, NEW_COMMENT
+}

--- a/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
+++ b/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-  NEW_COMMENT("notice"),
-  NEW_PARTICIPATION("post"),
-  NEW_NOTICE("notice"),
-  QUANTITY_FULLFIL("post");
+  NEW_COMMENT("notices"),
+  NEW_PARTICIPATION("posts"),
+  NEW_NOTICE("notices"),
+  QUANTITY_FULLFIL("posts");
 
   private final String belongingTo;
 }

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
@@ -16,4 +16,6 @@ public interface MemberPostQueryDSLRepository {
     Member findPostAdminByPostId(Long postId);
   
     PostResponseDTO.GetPost fetchDetailedPostByPostId(Long memberId, Long postId);
+
+    List<Member> findParticipatingMembersByPostId(Long postId);
 }

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepositoryImpl.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepositoryImpl.java
@@ -92,6 +92,21 @@ public class MemberPostQueryDSLRepositoryImpl implements MemberPostQueryDSLRepos
                 .fetchFirst() != null;
     }
 
+    @Override
+    public List<Member> findParticipatingMembersByPostId(Long postId){
+        QMemberPost memberPost = QMemberPost.memberPost;
+
+        BooleanBuilder conditions = new BooleanBuilder();
+        addCondition(conditions, memberPost.post.id.eq(postId));
+        addCondition(conditions, memberPost.isAuthorStatus.eq(IsAuthorStatus.PARTICIPATOR));
+
+        return jpaQueryFactory
+                .select(memberPost.member)
+                .from(memberPost)
+                .where(conditions)
+                .fetch();
+    }
+
     private MemberPost findMemberPostAdminByPostId(Long postId) {
         QPost post = QPost.post;
         QMember member = QMember.member;
@@ -116,4 +131,5 @@ public class MemberPostQueryDSLRepositoryImpl implements MemberPostQueryDSLRepos
     private void addCondition(BooleanBuilder builder, BooleanExpression condition) {
         builder.and(condition);
     }
+
 }

--- a/src/main/java/site/moamoa/backend/repository/notification/NotificationQueryDSLRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/notification/NotificationQueryDSLRepository.java
@@ -1,0 +1,10 @@
+package site.moamoa.backend.repository.notification;
+
+import site.moamoa.backend.domain.Notification;
+
+import java.util.List;
+
+public interface NotificationQueryDSLRepository {
+
+    List<Notification> findNotificationsByMemberId(Long memberId);
+}

--- a/src/main/java/site/moamoa/backend/repository/notification/NotificationQueryDSLRepositoryImpl.java
+++ b/src/main/java/site/moamoa/backend/repository/notification/NotificationQueryDSLRepositoryImpl.java
@@ -1,0 +1,25 @@
+package site.moamoa.backend.repository.notification;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import site.moamoa.backend.domain.Notification;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class NotificationQueryDSLRepositoryImpl implements NotificationQueryDSLRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Notification> findNotificationsByMemberId(Long memberId) {
+        QNotification notification = QNotification.notification;
+
+        BooleanBuilder conditions = new BooleanBuilder();
+        addCondition(conditions, notification.member.id.eq(memberId));
+        return jpaQueryFactory
+                .selectFrom(notification)
+                .where(conditions)
+                .fetch();
+    }
+}

--- a/src/main/java/site/moamoa/backend/repository/notification/NotificationQueryDSLRepositoryImpl.java
+++ b/src/main/java/site/moamoa/backend/repository/notification/NotificationQueryDSLRepositoryImpl.java
@@ -1,9 +1,11 @@
 package site.moamoa.backend.repository.notification;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import site.moamoa.backend.domain.Notification;
+import site.moamoa.backend.domain.QNotification;
 
 import java.util.List;
 
@@ -21,5 +23,8 @@ public class NotificationQueryDSLRepositoryImpl implements NotificationQueryDSLR
                 .selectFrom(notification)
                 .where(conditions)
                 .fetch();
+    }
+    private void addCondition(BooleanBuilder builder, BooleanExpression condition) {
+        builder.and(condition);
     }
 }

--- a/src/main/java/site/moamoa/backend/repository/notification/NotificationRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/notification/NotificationRepository.java
@@ -1,0 +1,8 @@
+package site.moamoa.backend.repository.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.moamoa.backend.domain.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/site/moamoa/backend/repository/notification/NotificationRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/notification/NotificationRepository.java
@@ -3,6 +3,6 @@ package site.moamoa.backend.repository.notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.moamoa.backend.domain.Notification;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationQueryDSLRepository {
 
 }

--- a/src/main/java/site/moamoa/backend/repository/post/PostQueryDSLRepositoryImpl.java
+++ b/src/main/java/site/moamoa/backend/repository/post/PostQueryDSLRepositoryImpl.java
@@ -54,7 +54,7 @@ public class PostQueryDSLRepositoryImpl implements PostQueryDSLRepository {
 
         BooleanBuilder conditions = new BooleanBuilder();
         if (town != null) {
-            addCondition(conditions, post.dealTown.eq(town));
+            addCondition(conditions, post.town.eq(town));
         }
 
         return jpaQueryFactory

--- a/src/main/java/site/moamoa/backend/service/component/command/comment/CommentCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/comment/CommentCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package site.moamoa.backend.service.component.command.comment;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,9 +8,14 @@ import site.moamoa.backend.converter.CommentConverter;
 import site.moamoa.backend.domain.Comment;
 import site.moamoa.backend.domain.Member;
 import site.moamoa.backend.domain.Notice;
+import site.moamoa.backend.domain.Notification;
+import site.moamoa.backend.domain.enums.NotificationStatus;
+import site.moamoa.backend.domain.enums.NotificationType;
 import site.moamoa.backend.service.module.comment.CommentModuleService;
 import site.moamoa.backend.service.module.member.MemberModuleService;
+import site.moamoa.backend.service.module.member_post.MemberPostModuleService;
 import site.moamoa.backend.service.module.notice.NoticeModuleService;
+import site.moamoa.backend.service.module.notification.NotificationModuleService;
 import site.moamoa.backend.web.dto.response.CommentResponseDTO;
 
 import static site.moamoa.backend.web.dto.request.CommentRequestDTO.AddComment;
@@ -22,22 +28,37 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final CommentModuleService commentModuleService;
     private final MemberModuleService memberModuleService;
     private final NoticeModuleService noticeModuleService;
+    private final MemberPostModuleService memberPostModuleService;
+    private final NotificationModuleService notificationModuleService;
+
 
     @Override
     public CommentResponseDTO.AddCommentResult registerComment(Long memberId, Long noticeId, AddComment request) {
 
-        Member member = memberModuleService.findMemberById(memberId);
+        Member authMember = memberModuleService.findMemberById(memberId);
         Notice notice = noticeModuleService.findNoticeById(noticeId);
 
         Comment newComment = CommentConverter.toComment(request);
 
-        newComment.setMember(member);
+        newComment.setMember(authMember);
         newComment.setNotice(notice);
+
         if (request.parentId() != null) {
             newComment.setParent(commentModuleService.findCommentById(request.parentId()));
         }
 
         commentModuleService.saveComment(newComment);
+        List<Notification> notifications = memberPostModuleService.findParticipatingMembersByPostId(notice.getPost().getId())
+            .stream().map(member -> Notification.builder()
+                .member(authMember)
+                .message(authMember.getNickname() + "님이 " + notice.getTitle() + "에 댓글을 달았어요!")
+                .type(NotificationType.NEW_NOTICE)
+                .referenceId(noticeId)
+                .status(NotificationStatus.UNREAD)
+                .build()
+            ).toList();
+
+        notificationModuleService.saveAllNotifications(notifications);
         return CommentConverter.toAddCommentResult(newComment);
     }
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/notice/NoticeCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/notice/NoticeCommandServiceImpl.java
@@ -41,7 +41,7 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
         noticeModuleService.saveNotice(newNotice);
 
         // 알림(공지사항 등록) 생성
-        List<Notification> notificationList = memberPostModuleService.findParticipatingMembersByPostId(postId).stream().map(member ->
+        List<Notification> notifications = memberPostModuleService.findParticipatingMembersByPostId(postId).stream().map(member ->
                         Notification.builder()
                                 .status(NotificationStatus.UNREAD)
                                 .type(NotificationType.NEW_NOTICE)
@@ -50,7 +50,7 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
                                 .member(member)
                                 .build())
                 .toList();
-        notificationModuleService.saveAllNotifications(notificationList);
+        notificationModuleService.saveAllNotifications(notifications);
 
         return NoticeConverter.toAddNoticeResult(newNotice);
     }

--- a/src/main/java/site/moamoa/backend/service/component/command/notice/NoticeCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/notice/NoticeCommandServiceImpl.java
@@ -7,11 +7,18 @@ import org.springframework.web.multipart.MultipartFile;
 import site.moamoa.backend.converter.NoticeConverter;
 import site.moamoa.backend.converter.PostImageConverter;
 import site.moamoa.backend.domain.Notice;
+import site.moamoa.backend.domain.Notification;
+import site.moamoa.backend.domain.enums.NotificationStatus;
+import site.moamoa.backend.domain.enums.NotificationType;
 import site.moamoa.backend.global.aws.s3.AmazonS3Manager;
+import site.moamoa.backend.service.module.member_post.MemberPostModuleService;
 import site.moamoa.backend.service.module.notice.NoticeModuleService;
+import site.moamoa.backend.service.module.notification.NotificationModuleService;
 import site.moamoa.backend.service.module.post.PostModuleService;
 import site.moamoa.backend.web.dto.request.NoticeRequestDTO.AddNotice;
 import site.moamoa.backend.web.dto.response.NoticeResponseDTO.AddNoticeResult;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -20,6 +27,8 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
 
     private final NoticeModuleService noticeModuleService;
     private final PostModuleService postModuleService;
+    private final MemberPostModuleService memberPostModuleService;
+    private final NotificationModuleService notificationModuleService;
     private final AmazonS3Manager amazonS3Manager;
 
     @Override
@@ -30,6 +39,18 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
         newNotice.setPost(postModuleService.findPostById(postId));
 
         noticeModuleService.saveNotice(newNotice);
+
+        // 알림(공지사항 등록) 생성
+        List<Notification> notificationList = memberPostModuleService.findParticipatingMembersByPostId(postId).stream().map(member ->
+                        Notification.builder()
+                                .status(NotificationStatus.UNREAD)
+                                .type(NotificationType.NEW_NOTICE)
+                                .message("참여한 " + postModuleService.findPostById(postId).getProductName() + "의 공동구매 공지사항 업데이트!")
+                                .referenceId(newNotice.getId())
+                                .member(member)
+                                .build())
+                .toList();
+        notificationModuleService.saveAllNotifications(notificationList);
 
         return NoticeConverter.toAddNoticeResult(newNotice);
     }

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -113,6 +113,17 @@ public class PostCommandServiceImpl implements PostCommandService {
         newMemberPost.setMember(authMember);
         newMemberPost.setPost(joinPost);
         memberPostModuleService.saveMemberPost(newMemberPost);
+        List<Notification> notifications = memberPostModuleService.findParticipatingMembersByPostId(postId)
+            .stream().map(member -> Notification.builder()
+                .member(authMember)
+                .message(authMember.getNickname() + "님이 " + joinPost.getProductName() + "공동구매에 참여했어요!")
+                .type(NotificationType.NEW_PARTICIPATION)
+                .referenceId(postId)
+                .status(NotificationStatus.UNREAD)
+                .build()
+            ).toList();
+
+        notificationModuleService.saveAllNotifications(notifications);
         return MemberPostConverter.toAddMemberPostResult(newMemberPost);
     }
 

--- a/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryService.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryService.java
@@ -1,0 +1,11 @@
+package site.moamoa.backend.service.component.query.notification;
+
+import site.moamoa.backend.web.dto.response.NotificationResponseDTO;
+
+import java.util.List;
+
+public interface NotificationQueryService {
+
+    List<NotificationResponseDTO.GetNotification> findNotificationByMemberId(Long memberId);
+
+}

--- a/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryService.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryService.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface NotificationQueryService {
 
-    List<NotificationResponseDTO.GetNotification> findNotificationByMemberId(Long memberId);
+    NotificationResponseDTO.GetNotifications findNotificationByMemberId(Long memberId);
 
 }

--- a/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package site.moamoa.backend.service.component.query.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.moamoa.backend.converter.NotificationConverter;
+import site.moamoa.backend.converter.PostConverter;
+import site.moamoa.backend.domain.Notification;
+import site.moamoa.backend.service.module.notification.NotificationModuleService;
+import site.moamoa.backend.web.dto.response.NotificationResponseDTO;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationQueryServiceImpl implements NotificationQueryService{
+    private final NotificationModuleService notificationModuleService;
+
+    @Override
+    public List<NotificationResponseDTO.GetNotification> findNotificationByMemberId(Long memberId) {
+        List<Notification> notifications = notificationModuleService.findNotificationsByMemberId(memberId);
+        return notifications.stream().map(notification -> NotificationConverter.toGetNotification(NotificationConverter.toNotificationDTO(notification)))
+                .toList();
+    }
+}

--- a/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/notification/NotificationQueryServiceImpl.java
@@ -18,9 +18,10 @@ public class NotificationQueryServiceImpl implements NotificationQueryService{
     private final NotificationModuleService notificationModuleService;
 
     @Override
-    public List<NotificationResponseDTO.GetNotification> findNotificationByMemberId(Long memberId) {
+    public NotificationResponseDTO.GetNotifications findNotificationByMemberId(Long memberId) {
         List<Notification> notifications = notificationModuleService.findNotificationsByMemberId(memberId);
-        return notifications.stream().map(notification -> NotificationConverter.toGetNotification(NotificationConverter.toNotificationDTO(notification)))
-                .toList();
+        return NotificationConverter.toGetNotifications(
+                notifications.stream().map(NotificationConverter::toNotificationDTO).toList()
+        );
     }
 }

--- a/src/main/java/site/moamoa/backend/service/component/query/post/PostQueryService.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/post/PostQueryService.java
@@ -4,7 +4,7 @@ import site.moamoa.backend.web.dto.response.PostResponseDTO;
 
 public interface PostQueryService {
 
-    PostResponseDTO.GetPosts findPostsByNear(Long memberId);
+    PostResponseDTO.GetPostsWithAddress findPostsByNear(Long memberId);
 
     PostResponseDTO.GetPosts findPostsByLatest();
 

--- a/src/main/java/site/moamoa/backend/service/component/query/post/PostQueryServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/query/post/PostQueryServiceImpl.java
@@ -28,12 +28,12 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final RedisModuleService redisModuleService;
 
     @Override
-    public PostResponseDTO.GetPosts findPostsByNear(Long memberId) {
+    public PostResponseDTO.GetPostsWithAddress findPostsByNear(Long memberId) {
         Address address = memberModuleService.findMemberById(memberId).getAddress();
         List<Post> posts = postModuleService.findPostsByNear(address.getLatitude(), address.getLatitude());
 
-        return PostConverter.toGetPosts(
-                posts.stream().map(post -> PostConverter.toSimplePostDTO(post, post.getPostImages())).toList()
+        return PostConverter.toGetPostsWithAddress(
+                posts.stream().map(post -> PostConverter.toSimplePostDtoWithAddress(post, post.getPostImages())).toList()
         );
     }
 

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
@@ -25,5 +25,7 @@ public interface MemberPostModuleService {
     void checkMemberPostExists(Long memberId, Long postId);
 
     PostResponseDTO.GetPost fetchDetailedPostByPostId(Long memberId, Long postId);
+
+    List<Member> findParticipatingMembersByPostId(Long postId);
 }
 

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
@@ -67,4 +67,9 @@ public class MemberPostModuleServiceImpl implements MemberPostModuleService {
     public PostResponseDTO.GetPost fetchDetailedPostByPostId(Long memberId, Long postId) {
         return memberPostRepository.fetchDetailedPostByPostId(memberId, postId);
     }
+
+    @Override
+    public List<Member> findParticipatingMembersByPostId(Long postId) {
+        return memberPostRepository.findParticipatingMembersByPostId(postId);
+    }
 }

--- a/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleService.java
@@ -1,0 +1,9 @@
+package site.moamoa.backend.service.module.notification;
+
+import site.moamoa.backend.domain.Notification;
+
+import java.util.List;
+
+public interface NotificationModuleService {
+    void saveAllNotifications(List<Notification> notificationList);
+}

--- a/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface NotificationModuleService {
     void saveAllNotifications(List<Notification> notificationList);
+    List<Notification> findNotificationsByMemberId(Long memberId);
 }

--- a/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleServiceImpl.java
@@ -1,0 +1,18 @@
+package site.moamoa.backend.service.module.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.moamoa.backend.domain.Notification;
+import site.moamoa.backend.repository.notification.NotificationRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationModuleServiceImpl implements NotificationModuleService{
+    private final NotificationRepository notificationRepository;
+    @Override
+    public void saveAllNotifications(List<Notification> notificationList){
+        notificationRepository.saveAll(notificationList);
+    }
+}

--- a/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleServiceImpl.java
@@ -15,4 +15,11 @@ public class NotificationModuleServiceImpl implements NotificationModuleService{
     public void saveAllNotifications(List<Notification> notificationList){
         notificationRepository.saveAll(notificationList);
     }
+
+    @Override
+    public List<Notification> findNotificationsByMemberId(Long memberId){
+
+        return notificationRepository.findNotificationsByMemberId(memberId);
+    }
+
 }

--- a/src/main/java/site/moamoa/backend/web/controller/NotificationController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/NotificationController.java
@@ -28,10 +28,10 @@ public class NotificationController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
     })
-    public ApiResponseDTO<List<NotificationResponseDTO.GetNotification>> getNotificationByMemberId(
+    public ApiResponseDTO<NotificationResponseDTO.GetNotifications> getNotificationByMemberId(
             @AuthenticationPrincipal AuthInfoDTO auth
     ) {
-        List<NotificationResponseDTO.GetNotification> notificationList = notificationQueryService.findNotificationByMemberId(auth.id());
+        NotificationResponseDTO.GetNotifications notificationList = notificationQueryService.findNotificationByMemberId(auth.id());
         return ApiResponseDTO.onSuccess(notificationList);
     }
 }

--- a/src/main/java/site/moamoa/backend/web/controller/NotificationController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/NotificationController.java
@@ -1,0 +1,37 @@
+package site.moamoa.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.moamoa.backend.api_payload.ApiResponseDTO;
+import site.moamoa.backend.service.component.query.notification.NotificationQueryService;
+import site.moamoa.backend.web.dto.base.AuthInfoDTO;
+import site.moamoa.backend.web.dto.response.NotificationResponseDTO;
+
+import java.util.List;
+
+@Tag(name = "알림 API", description = "알림 페이지 관련 API (개발중)")
+@RequiredArgsConstructor
+@RestController
+public class NotificationController {
+    private final NotificationQueryService notificationQueryService;
+    @GetMapping("/api/notifications")
+    @Operation(
+            summary = "알림 조회",
+            description = "현재 접속 중인 멤버의 알림을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+    })
+    public ApiResponseDTO<List<NotificationResponseDTO.GetNotification>> getNotificationByMemberId(
+            @AuthenticationPrincipal AuthInfoDTO auth
+    ) {
+        List<NotificationResponseDTO.GetNotification> notificationList = notificationQueryService.findNotificationByMemberId(auth.id());
+        return ApiResponseDTO.onSuccess(notificationList);
+    }
+}

--- a/src/main/java/site/moamoa/backend/web/controller/PostController.java
+++ b/src/main/java/site/moamoa/backend/web/controller/PostController.java
@@ -74,10 +74,11 @@ public class PostController {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @ApiResponse(responseCode = "MEMBER404", description = "해당 사용자를 찾을 수 없습니다.", content = @Content)
     })
-    public ApiResponseDTO<GetPosts> getPostsByNear(
+    public ApiResponseDTO<GetPostsWithAddress> getPostsByNear(
             @AuthenticationPrincipal AuthInfoDTO auth
     ) {
-        GetPosts resultDTO = postQueryService.findPostsByNear(auth.id());
+
+        GetPostsWithAddress resultDTO = postQueryService.findPostsByNear(auth.id());
         return ApiResponseDTO.onSuccess(resultDTO);
     }
 

--- a/src/main/java/site/moamoa/backend/web/dto/base/NotificationDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/base/NotificationDTO.java
@@ -4,12 +4,16 @@ import lombok.Builder;
 import site.moamoa.backend.domain.enums.NotificationStatus;
 import site.moamoa.backend.domain.enums.NotificationType;
 
+import java.time.LocalDateTime;
+
 
 @Builder
 public record NotificationDTO(
     Long notificationId,
     String message,
     NotificationType type,
-    NotificationStatus status
+    Long referenceId,
+    NotificationStatus status,
+    LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/site/moamoa/backend/web/dto/base/NotificationDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/base/NotificationDTO.java
@@ -1,0 +1,15 @@
+package site.moamoa.backend.web.dto.base;
+
+import lombok.Builder;
+import site.moamoa.backend.domain.enums.NotificationStatus;
+import site.moamoa.backend.domain.enums.NotificationType;
+
+
+@Builder
+public record NotificationDTO(
+    Long notificationId,
+    String message,
+    NotificationType type,
+    NotificationStatus status
+) {
+}

--- a/src/main/java/site/moamoa/backend/web/dto/base/NotificationDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/base/NotificationDTO.java
@@ -2,7 +2,6 @@ package site.moamoa.backend.web.dto.base;
 
 import lombok.Builder;
 import site.moamoa.backend.domain.enums.NotificationStatus;
-import site.moamoa.backend.domain.enums.NotificationType;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +10,7 @@ import java.time.LocalDateTime;
 public record NotificationDTO(
     Long notificationId,
     String message,
-    NotificationType type,
+    String type,
     Long referenceId,
     NotificationStatus status,
     LocalDateTime createdAt

--- a/src/main/java/site/moamoa/backend/web/dto/base/PostDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/base/PostDTO.java
@@ -17,6 +17,7 @@ public record PostDTO(
         List<String> imageUrl,
         Address dealLocation,
         String dealTown,
+        String town,
         Integer price,
         String description,
         Integer viewCount

--- a/src/main/java/site/moamoa/backend/web/dto/base/SimplePostDtoWithAddress.java
+++ b/src/main/java/site/moamoa/backend/web/dto/base/SimplePostDtoWithAddress.java
@@ -1,0 +1,12 @@
+package site.moamoa.backend.web.dto.base;
+
+import lombok.Builder;
+import site.moamoa.backend.domain.embedded.Address;
+
+@Builder
+public record SimplePostDtoWithAddress(
+    SimplePostDTO simplePostDTO,
+    Address address
+) {
+
+}

--- a/src/main/java/site/moamoa/backend/web/dto/request/PostRequestDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/request/PostRequestDTO.java
@@ -26,6 +26,8 @@ public class PostRequestDTO {
             @NotNull
             String dealTown,
             @NotNull
+            String town,
+            @NotNull
             Integer price,
             String description
     ) {

--- a/src/main/java/site/moamoa/backend/web/dto/response/NotificationResponseDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/response/NotificationResponseDTO.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 import site.moamoa.backend.web.dto.base.NoticeDTO;
 import site.moamoa.backend.web.dto.base.NotificationDTO;
 
+import java.util.List;
+
 public class NotificationResponseDTO {
     @Builder
-    public record GetNotification (
-            NotificationDTO notificationDTO
+    public record GetNotifications (
+            List<NotificationDTO> notificationDTOList
     ) {
     }
 }

--- a/src/main/java/site/moamoa/backend/web/dto/response/NotificationResponseDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/response/NotificationResponseDTO.java
@@ -1,0 +1,13 @@
+package site.moamoa.backend.web.dto.response;
+
+import lombok.Builder;
+import site.moamoa.backend.web.dto.base.NoticeDTO;
+import site.moamoa.backend.web.dto.base.NotificationDTO;
+
+public class NotificationResponseDTO {
+    @Builder
+    public record GetNotification (
+            NotificationDTO notificationDTO
+    ) {
+    }
+}

--- a/src/main/java/site/moamoa/backend/web/dto/response/PostResponseDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/response/PostResponseDTO.java
@@ -7,6 +7,7 @@ import site.moamoa.backend.web.dto.base.SimplePostDTO;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import site.moamoa.backend.web.dto.base.SimplePostDtoWithAddress;
 
 import static site.moamoa.backend.web.dto.response.NoticeResponseDTO.GetSimpleNotice;
 
@@ -23,6 +24,12 @@ public class PostResponseDTO {
     @Builder
     public record GetPosts(
             List<SimplePostDTO> SimplePostDtoList
+    ) {
+    }
+
+    @Builder
+    public record GetPostsWithAddress(
+        List<SimplePostDtoWithAddress> SimplePostDtoList
     ) {
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,7 +61,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 100
@@ -112,7 +112,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/80

### 💡 작업동기
- 각 유형별 알림 생성 기능 및 조회 기능 구현

### 🔑 주요 변경사항
1. 알림 생성 기능 구현
 - 공지사항에 댓글 등록 시, 알림 생성 기능 구현
 - 어떤 멤버가 공동구매 참여 시, 알림 생성 기능 구현
 - 공지사항 등록 시, 알림 생성 기능 구현
 - 공동구매 참여 완료 시, 알림 생성 기능 구현
2. 멤버 본인의 알림 목록 조회 기능 구현



### 관련 이슈
 - https://github.com/moa-moa-service/moamoa-backend/issues/80