### PR TITLE
:bug: Fix: 알림 생성 기능 수정

### DIFF
--- a/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
+++ b/src/main/java/site/moamoa/backend/domain/enums/NotificationType.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-  NEW_COMMENT("notices"),
-  NEW_PARTICIPATION("posts"),
-  NEW_NOTICE("notices"),
-  QUANTITY_FULFILL("posts");
+  NEW_COMMENT("댓글"),
+  NEW_PARTICIPATION("공동구매"),
+  NEW_NOTICE("공지사항"),
+  QUANTITY_FULFILL("공동구매");
 
   private final String belongingTo;
 }

--- a/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
+++ b/src/main/java/site/moamoa/backend/repository/mapping/member_post/MemberPostQueryDSLRepository.java
@@ -16,4 +16,6 @@ public interface MemberPostQueryDSLRepository {
     MemberPost findMemberPostAdminByPostId(Long postId);
 
     List<Member> findParticipatingMembersByPostId(Long postId);
+
+  List<Member> findMembersByPostIdExcludingMember(Long postId, Long memberId);
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/comment/CommentCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/comment/CommentCommandServiceImpl.java
@@ -47,16 +47,19 @@ public class CommentCommandServiceImpl implements CommentCommandService {
             newComment.setParent(commentModuleService.findCommentById(request.parentId()));
         }
 
+        Long postId = notice.getPost().getId();
         commentModuleService.saveComment(newComment);
-        List<Notification> notifications = memberPostModuleService.findParticipatingMembersByPostId(notice.getPost().getId())
+
+        List<Notification> notifications = memberPostModuleService.findParticipatingMembersExcludingMember(postId, memberId)
             .stream().map(member -> Notification.builder()
-                .member(authMember)
+                .member(member)
                 .message(authMember.getNickname() + "님이 " + notice.getTitle() + "에 댓글을 달았어요!")
                 .type(NotificationType.NEW_NOTICE)
                 .referenceId(noticeId)
                 .status(NotificationStatus.UNREAD)
                 .build()
             ).toList();
+
 
         notificationModuleService.saveAllNotifications(notifications);
         return CommentConverter.toAddCommentResult(newComment);

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleService.java
@@ -28,5 +28,7 @@ public interface MemberPostModuleService {
     List<Post> findPostsByRecruitingAndParticipating(Long memberId, IsAuthorStatus isAuthorStatus, CapacityStatus capacityStatus);
 
     MemberPost fetchDetailedPostByPostId(Long postId);
+
+    List<Member> findParticipatingMembersExcludingMember(Long postId, Long memberId);
 }
 

--- a/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/member_post/MemberPostModuleServiceImpl.java
@@ -76,4 +76,9 @@ public class MemberPostModuleServiceImpl implements MemberPostModuleService {
     public List<Member> findParticipatingMembersByPostId(Long postId) {
         return memberPostRepository.findParticipatingMembersByPostId(postId);
     }
+
+    @Override
+    public List<Member> findParticipatingMembersExcludingMember(Long postId, Long memberId) {
+        return memberPostRepository.findMembersByPostIdExcludingMember(postId, memberId);
+    }
 }

--- a/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleService.java
+++ b/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleService.java
@@ -5,6 +5,7 @@ import site.moamoa.backend.domain.Notification;
 import java.util.List;
 
 public interface NotificationModuleService {
+    void saveNotification(Notification notification);
     void saveAllNotifications(List<Notification> notificationList);
     List<Notification> findNotificationsByMemberId(Long memberId);
 }

--- a/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/module/notification/NotificationModuleServiceImpl.java
@@ -11,6 +11,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationModuleServiceImpl implements NotificationModuleService{
     private final NotificationRepository notificationRepository;
+
+    @Override
+    public void saveNotification(Notification notification) {
+        notificationRepository.save(notification);
+    }
+
     @Override
     public void saveAllNotifications(List<Notification> notificationList){
         notificationRepository.saveAll(notificationList);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/93

### 💡 작업동기
- 알림 생성 기능 수정

### 🔑 주요 변경사항
- 공지사항 댓글 등록 시, 알림 생성 기능 수정→ 공동구매 작성자, 참여자 모두 (댓글 단 본인 제외)
- 공동구매 참여 시 , 알림 기능 수정 → 공동구매 작성자에게만 알림 생성
- 공동구매 모집완료 시, 알림 생성 기능 수정 → available이 0이 되는 순간 알림 등록으로 수정, 공동구매 작성자, 참여자 모두에게


### 관련 이슈
https://github.com/moa-moa-service/moamoa-backend/issues/93