### PR TITLE
🚑 Hotfix: Swagger 환경 개선 및 마감 로직, 일부 DTO 필드 추가

### DIFF
--- a/src/main/java/site/moamoa/backend/config/swagger/SwaggerConfig.java
+++ b/src/main/java/site/moamoa/backend/config/swagger/SwaggerConfig.java
@@ -5,16 +5,28 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
+
+    @Value("${server.url.local}")
+    private String localUrl;
+
+    @Value("${server.url.dev-http}")
+    private String devHttpUrl;
+
+    @Value("${server.url.dev-https}")
+    private String devHttpsUrl;
 
     @Bean
     public GroupedOpenApi defaultAPI() {
@@ -31,6 +43,18 @@ public class SwaggerConfig {
                 .version("0.1")
                 .description("모아모아 서비스의 API Docs 입니다.");
 
+        Server localServer = new Server();
+        localServer.setDescription("Local Server");
+        localServer.setUrl(localUrl);
+
+        Server devHttpsServer = new Server();
+        devHttpsServer.setDescription("Develop Https Server");
+        devHttpsServer.setUrl(devHttpsUrl);
+
+        Server devHttpServer = new Server();
+        devHttpServer.setDescription("Develop Http Server");
+        devHttpServer.setUrl(devHttpUrl);
+
         SecurityScheme securityScheme = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
@@ -44,6 +68,7 @@ public class SwaggerConfig {
                 .components(new Components()
                         .addSecuritySchemes("bearerAuth", securityScheme))
                 .security(Collections.singletonList(securityRequirement))
+                .servers(Arrays.asList(localServer, devHttpsServer, devHttpServer))
                 .info(info);
     }
 }

--- a/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
+++ b/src/main/java/site/moamoa/backend/service/component/command/post/PostCommandServiceImpl.java
@@ -116,6 +116,7 @@ public class PostCommandServiceImpl implements PostCommandService {
 
         if (joinPost.getAvailable() == 0) {
             createNotificationForNoticeUpdate(postId, joinPost);
+            joinPost.updateStatusToFull();
         }
 
         memberPostModuleService.saveMemberPost(newMemberPost);
@@ -126,8 +127,11 @@ public class PostCommandServiceImpl implements PostCommandService {
 
     @Override
     public void updatePostViewCount(Long memberId, Long postId) {
+        Post post = postModuleService.findPostById(postId);
+        if (post.getDeadline().plusDays(1).isBefore(LocalDateTime.now())) {
+            post.updateStatusToNotFull();
+        }
         if (redisModuleService.isNewPostViewRecord(memberId, postId)) {
-            Post post = postModuleService.findPostById(postId);
             post.updateViewCount();
         }
     }

--- a/src/main/java/site/moamoa/backend/web/dto/base/SimplePostDTO.java
+++ b/src/main/java/site/moamoa/backend/web/dto/base/SimplePostDTO.java
@@ -11,6 +11,7 @@ public record SimplePostDTO(
         String dealTown,
         Integer viewCount,
         Integer personnel,
+        Integer available,
         Integer dDay,
         Integer price,
         CapacityStatus status

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,12 @@ default:
   profileImage:
     url: ${default.profile.image.url}
 
+server:
+  url:
+    local: ${local.url}
+    dev-https: ${dev.https.url}
+    dev-http: ${dev.http.url}
+
 ---
 # Local Setting
 spring:
@@ -61,7 +67,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- ref/82

### 💡 작업동기
- `Swagger` 테스트시 `https` 지원이 필요합니다.
- 공동구매 마감로직이 누락되었습니다.
- 일부 응답에 이용가능 수량 필드가 필요합니다.

### 🔑 주요 변경사항
- 여러 서버에서 테스트 할 수 있도록 변경
    - `local`
    - `https` `develop`
    - `http` `develop`
- `loca`l에서 테스트시 환경변수 설정이 필요
- `SimplePostDTO`: `available` 필드 추가
- `PostCommandServiceImpl`: 참여 가능 수량 소진시, 마감 로직 추가, 상세 조회시 마감 여부 업데이트

### 관련 이슈
- #82 